### PR TITLE
Fix compilation issues

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(KVER),)
+KVER=$(shell uname -r)
+endif
+
 ifeq ($(WIFI_MODE),)
 RT28xx_MODE = STA
 else
@@ -217,10 +221,10 @@ endif
 
 ifeq ($(PLATFORM),PC)
 # Linux 2.6
-LINUX_SRC = /lib/modules/$(shell uname -r)/build
+LINUX_SRC = /lib/modules/$(KVER)/build
 # Linux 2.4 Change to your local setting
 #LINUX_SRC = /usr/src/linux-2.4
-LINUX_SRC_MODULE = /lib/modules/$(shell uname -r)/kernel/drivers/net/wireless/
+LINUX_SRC_MODULE = /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 CROSS_COMPILE = 
 endif
 

--- a/src/chips/mt7601.c
+++ b/src/chips/mt7601.c
@@ -1488,7 +1488,7 @@ NTSTATUS MT7601DisableTxRx(
 	UINT32 MaxRetry;
 
 	if (!IS_MT7601(pAd))
-		return;
+		return STATUS_UNSUCCESSFUL;
 
 	DBGPRINT(RT_DEBUG_TRACE, ("----> %s\n", __FUNCTION__));
 
@@ -1712,7 +1712,12 @@ NTSTATUS MT7601DisableTxRx(
 	return STATUS_SUCCESS;
 }
 
-
+VOID MT7601DisableTxRxNC(
+	RTMP_ADAPTER *pAd,
+	UCHAR Level)
+{
+    (void)MT7601DisableTxRx(pAd, Level);
+}
 #ifdef RTMP_USB_SUPPORT
 VOID MT7601UsbAsicRadioOff(RTMP_ADAPTER *pAd, UCHAR Stage)
 {
@@ -1727,7 +1732,7 @@ VOID MT7601UsbAsicRadioOff(RTMP_ADAPTER *pAd, UCHAR Stage)
 
 	if (Stage == SUSPEND_RADIO_OFF)
 	{
-		MT7601DisableTxRx(pAd, RTMP_HALT);
+		MT7601DisableTxRxNC(pAd, RTMP_HALT);
 	}
 	else
 	{
@@ -3384,7 +3389,7 @@ VOID MT7601_Init(RTMP_ADAPTER *pAd)
 	pChipOps->SetRxAnt = MT7601SetRxAnt;
 
 
-	pChipOps->DisableTxRx = MT7601DisableTxRx;
+	pChipOps->DisableTxRx = MT7601DisableTxRxNC;
 
 #ifdef RTMP_USB_SUPPORT
 	pChipOps->AsicRadioOn = MT7601UsbAsicRadioOn;

--- a/src/common/cmm_info.c
+++ b/src/common/cmm_info.c
@@ -5722,12 +5722,13 @@ INT set_force_amsdu(RTMP_ADAPTER *pAd, PSTRING arg)
 #ifdef RLT_RF
 INT set_rf(RTMP_ADAPTER *pAd, PSTRING arg)
 {
-	INT bank_id = 0, rf_id = 0, rv = 0;
-	UCHAR rf_val = 0;
+	INT bank_id = 0, rf_id = 0, rv = 0, rf_rd = 0;
+	UCHAR rf_val;
 	
 	if (arg)
 	{
-		rv = sscanf(arg, "%d-%d-%x", &(bank_id), &(rf_id), &(rf_val));
+		rv = sscanf(arg, "%d-%d-%x", &(bank_id), &(rf_id), &(rf_rd));
+		rf_val = (UCHAR)rf_rd;
 		DBGPRINT(RT_DEBUG_TRACE, ("%s():rv = %d, bank_id = %d, rf_id = %d, rf_val = 0x%02x\n", __FUNCTION__, rv, bank_id, rf_id, rf_val));
 		if (rv == 3)
 		{

--- a/src/common/cmm_mac_usb.c
+++ b/src/common/cmm_mac_usb.c
@@ -559,7 +559,7 @@ NDIS_STATUS	RTMPAllocTxRxRingMemory(
 	IN	PRTMP_ADAPTER	pAd)
 {	
 	NDIS_STATUS Status = NDIS_STATUS_FAILURE;
-	PTX_CONTEXT pNullContext   = &(pAd->NullContext);
+	PTX_CONTEXT pNullContext   = &(pAd->NullContext[0]);
 	PTX_CONTEXT pPsPollContext = &(pAd->PsPollContext);
 	PCMD_RSP_CONTEXT pCmdRspEventContext = &(pAd->CmdRspEventContext);
 	INT i, acidx;
@@ -1163,7 +1163,7 @@ VOID	RTMPFreeTxRxRingMemory(
 	IN	PRTMP_ADAPTER	pAd)
 {
 	UINT                i, acidx;
-	PTX_CONTEXT			pNullContext   = &pAd->NullContext;
+	PTX_CONTEXT			pNullContext   = &(pAd->NullContext[0]);
 	PTX_CONTEXT			pPsPollContext = &pAd->PsPollContext;
 	PCMD_RSP_CONTEXT pCmdRspEventContext = &(pAd->CmdRspEventContext);
 

--- a/src/common/rtusb_bulk.c
+++ b/src/common/rtusb_bulk.c
@@ -1677,7 +1677,7 @@ VOID	RTUSBCancelPendingBulkOutIRP(
 	pAd->BulkOutPending[MGMTPIPEIDX] = FALSE;
 	/*RTMP_IRQ_UNLOCK(pLock, IrqFlags);*/
 
-	pNullContext = &(pAd->NullContext);
+	pNullContext = &(pAd->NullContext[0]);
 	if (pNullContext->IRPPending == TRUE)
 		RTUSB_UNLINK_URB(pNullContext->pUrb);
 

--- a/src/include/os/rt_linux.h
+++ b/src/include/os/rt_linux.h
@@ -279,7 +279,7 @@ typedef struct file* RTMP_OS_FD;
 
 typedef struct _OS_FS_INFO_
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,12,0) || SYNOLOGY
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,12,0) || defined (SYNOLOGY)
 	uid_t				fsuid;
 	gid_t				fsgid;
 #else

--- a/src/include/rtmp_and.h
+++ b/src/include/rtmp_and.h
@@ -131,7 +131,7 @@ INT AndesFunSetOP(PRTMP_ADAPTER pAd, UINT32 FunID, UINT32 Param);
 INT AndesPwrSavingOP(PRTMP_ADAPTER pAd, UINT32 PwrOP, UINT32 PwrLevel, 
 					UINT32 ListenInterval, UINT32 PreTBTTLeadTime,
 					UINT8 TIMByteOffset, UINT8 TIMBytePattern);
-INT AndesCalibrationOP(PRTMP_ADAPTER, UINT32 CalibrationID, UINT32 Param);
+VOID AndesCalibrationOP(PRTMP_ADAPTER, UINT32 CalibrationID, UINT32 Param);
 BOOLEAN IsInBandCmdProcessing(PRTMP_ADAPTER pAd);
 UCHAR GetCmdRspNum(PRTMP_ADAPTER pAd);
 INT AndesLedOP(PRTMP_ADAPTER pAd, UCHAR LedIdx,UCHAR LinkStatus);

--- a/src/mcu/rtmp_and.c
+++ b/src/mcu/rtmp_and.c
@@ -2009,7 +2009,7 @@ INT AndesFunSetOP(PRTMP_ADAPTER pAd, UINT32 FunID, UINT32 Param)
 }
 
 
-INT AndesCalibrationOP(PRTMP_ADAPTER pAd, UINT32 CalibrationID, UINT32 Param)
+VOID AndesCalibrationOP(PRTMP_ADAPTER pAd, UINT32 CalibrationID, UINT32 Param)
 {
 
 	struct CMD_UNIT CmdUnit;
@@ -2048,8 +2048,6 @@ INT AndesCalibrationOP(PRTMP_ADAPTER pAd, UINT32 CalibrationID, UINT32 Param)
 	Ret = AsicSendCmdToAndes(pAd, &CmdUnit);
 
 	os_free_mem(NULL, Buf);
-
-	return NDIS_STATUS_SUCCESS;
 }
 
 INT AndesLedOP(

--- a/src/mcu/rtmp_mcu.c
+++ b/src/mcu/rtmp_mcu.c
@@ -29,7 +29,8 @@
 
 INT MCUBurstWrite(PRTMP_ADAPTER pAd, UINT32 Offset, UINT32 *Data, UINT32 Cnt)
 {
-	RTUSBMultiWrite_nBytes(pAd, Offset, Data, Cnt * 4, 64); 
+	RTUSBMultiWrite_nBytes(pAd, Offset, (PUCHAR)Data, Cnt * 4, 64);
+	return 0;
 }
 
 INT MCURandomWrite(PRTMP_ADAPTER pAd, RTMP_REG_PAIR *RegPair, UINT32 Num)
@@ -38,6 +39,8 @@ INT MCURandomWrite(PRTMP_ADAPTER pAd, RTMP_REG_PAIR *RegPair, UINT32 Num)
 	
 	for (Index = 0; Index < Num; Index++)
 		RTMP_IO_WRITE32(pAd, RegPair->Register, RegPair->Value);
+	
+	return 0;
 }
 
 VOID ChipOpsMCUHook(PRTMP_ADAPTER pAd, enum MCU_TYPE MCUType)
@@ -68,8 +71,8 @@ VOID ChipOpsMCUHook(PRTMP_ADAPTER pAd, enum MCU_TYPE MCUType)
 		pChipOps->RFRandomRead = AndesRFRandomRead;
 		pChipOps->ReadModifyWrite = AndesReadModifyWrite;
 		pChipOps->RFReadModifyWrite = AndesRFReadModifyWrite;
-		pChipOps->RandomWrite = AndesRandomWrite;
-		pChipOps->RFRandomWrite = AndesRFRandomWrite;
+		pChipOps->RandomWrite = AndesRandomWritePair;
+		pChipOps->RFRandomWrite = AndesRFRandomWritePair;
 		pChipOps->PwrSavingOP = AndesPwrSavingOP;
 	}
 #endif

--- a/src/os/linux/rt_linux.c
+++ b/src/os/linux/rt_linux.c
@@ -2051,7 +2051,7 @@ VOID RtmpDrvAllRFPrint(
 		if (file_w->f_op && file_w->f_op->write) {
 			file_w->f_pos = 0;
 			/* write data to file */
-			file_w->f_op->write(file_w, pBuf, BufLen, &file_w->f_pos);
+			file_w->f_op->write(file_w, (PCHAR)pBuf, (size_t)BufLen, &file_w->f_pos);
 		}
 		filp_close(file_w, NULL);
 	}

--- a/src/os/linux/rt_usb.c
+++ b/src/os/linux/rt_usb.c
@@ -534,7 +534,7 @@ static void cmd_rsp_event_tasklet(unsigned long data)
 	unsigned int		IrqFlags;
 
 	pUrb = (purbb_t)data;
-	pCmdRspEventContext	= (PRX_CONTEXT)RTMP_USB_URB_DATA_GET(pUrb);
+	pCmdRspEventContext	= (PCMD_RSP_CONTEXT)RTMP_USB_URB_DATA_GET(pUrb);
 	Status = RTMP_USB_URB_STATUS_GET(pUrb);
 	pAd = pCmdRspEventContext->pAd;
 

--- a/src/os/linux/rt_usb_util.c
+++ b/src/os/linux/rt_usb_util.c
@@ -150,7 +150,7 @@ int rausb_autopm_get_interface (
 	struct usb_interface	*intf =(struct usb_interface *)intfsrc;
 
 
-	usb_autopm_get_interface(intf);
+	return usb_autopm_get_interface(intf);
 
 }
 

--- a/src/sta/rtmp_data.c
+++ b/src/sta/rtmp_data.c
@@ -520,7 +520,7 @@ if (0 /*!(pRxInfo->Mcast || pRxInfo->Bcast)*/){
 			    So, the EAP Request is dropped.
 			    The patch lookup pEntry from MacTable.
 			*/
-			pEntry = MacTableLookup(pAd, &pHeader->Addr2);
+			pEntry = MacTableLookup(pAd, &(pHeader->Addr2[0]));
 			if ( pEntry == NULL )
 			{
 				RELEASE_NDIS_PACKET(pAd, pRxPacket,

--- a/src/sta/sta_cfg.c
+++ b/src/sta/sta_cfg.c
@@ -7615,7 +7615,7 @@ RtmpIoctl_rt_ioctl_siwgenie(
 				pAd->StaCfg.WpaAssocIeLen = length;
 				NdisMoveMemory(pAd->StaCfg.pWpaAssocIe, pData, pAd->StaCfg.WpaAssocIeLen);
 				pAd->StaCfg.bRSN_IE_FromWpaSupplicant = TRUE;
-				eid_ptr = pAd->StaCfg.pWpaAssocIe;
+				eid_ptr = (PEID_STRUCT)(pAd->StaCfg.pWpaAssocIe);
 				while (((UCHAR *)eid_ptr + eid_ptr->Len + 1) < ((UCHAR *)pAd->StaCfg.pWpaAssocIe + pAd->StaCfg.WpaAssocIeLen))
 				{
 					if ( eid_ptr->Eid == IE_WPA )

--- a/src/sta/sync.c
+++ b/src/sta/sync.c
@@ -2179,7 +2179,7 @@ VOID PeerBeacon(
 											ie_list->HtCapabilityLen, 
 											&ie_list->AddHtInfo,
 											ie_list->AddHtInfoLen,
-											&ie_list,
+											NULL,
 											ie_list->CapabilityInfo) == FALSE)
 					{
 						DBGPRINT(RT_DEBUG_TRACE, ("ADHOC - Add Entry failed.\n"));


### PR DESCRIPTION
Fixed compilation issues (and probably some bugs) encountered on CentOS7 kernels 3.10 and 4.10
Also added a feature that allows to compile for a non-current kernel.